### PR TITLE
fix: enable sanity start to work with copied env vars

### DIFF
--- a/template/studio/sanity.json
+++ b/template/studio/sanity.json
@@ -1,8 +1,8 @@
 {
   "root": true,
   "api": {
-    "projectId": "PLACEHOLDER_ENV_VARIABLES_WILL_HANDLE_FOR_US",
-    "dataset": "PLACEHOLDER_ENV_VARIABLES_WILL_HANDLE_FOR_US"
+    "projectId": "placeholder",
+    "dataset": "placeholder"
   },
   "project": {
     "name": "Next.js Comment-enabled blog",
@@ -17,9 +17,7 @@
   ],
   "env": {
     "development": {
-      "plugins": [
-        "@sanity/vision"
-      ]
+      "plugins": ["@sanity/vision"]
     }
   },
   "parts": [


### PR DESCRIPTION
https://github.com/sanity-io/sanity-template-nextjs-blog-comments/issues/5 fix with solution suggested from @neilbradley


the command `npm run start:sanity` will not work out of the box without this change